### PR TITLE
AX-1723:  Credentials not downloading very first time when Converge app is installed from Mission Control

### DIFF
--- a/app/src/main/java/com/elavon/converge/ElavonConvergeProcessorApplication.java
+++ b/app/src/main/java/com/elavon/converge/ElavonConvergeProcessorApplication.java
@@ -93,13 +93,13 @@ public class ElavonConvergeProcessorApplication extends Application {
 
     public boolean isMerchantCredsAvailableInPref() {
         boolean merchantCredsExists = false;
-
+        Log.d(TAG, "Checking for Merchant credentials in Shared Preference.");
         try {
             SharedPreferences prefs = getSharedPreferences(Constants.MERCHANT_CREDS_PREFS, MODE_PRIVATE);
             String userId = prefs.getString(Constants.SSL_USER_ID, null);
             String merchantId = prefs.getString(Constants.SSL_MERCHANT_ID, null);
             String sslPin = prefs.getString(Constants.SSL_PIN, null);
-
+            Log.d(TAG, "Merchant credentials from Shared Preference " + userId + " " + merchantId + " ");
             if (!TextUtils.isEmpty(userId) && !TextUtils.isEmpty(merchantId)
                     && !TextUtils.isEmpty(sslPin)) {
                 merchantCredsExists = true;
@@ -122,6 +122,7 @@ public class ElavonConvergeProcessorApplication extends Application {
                 editor.putString(Constants.SSL_MERCHANT_ID, merchantId);
                 editor.putString(Constants.SSL_PIN, pin);
                 editor.commit();
+                Log.d(TAG, "Updated Merchant credentials to Shared Preference.");
             }
         } catch (Exception e) {
             Log.e(TAG, "Exception while updating merchant creds to shared pref");

--- a/app/src/main/java/com/elavon/converge/config/ConfigLoader.java
+++ b/app/src/main/java/com/elavon/converge/config/ConfigLoader.java
@@ -37,7 +37,12 @@ public class ConfigLoader {
             case TEST:
             default:
                 configResource = R.raw.config_test;
-                File f = new File(Environment.getExternalStorageDirectory() + "/credential.json");
+                /*
+                * Commenting this default credentials read logic from json file
+                * for AX-1723 - Credentials not downloading very first time when Converge app is
+                * installed from Mission Control
+                */
+                /*File f = new File(Environment.getExternalStorageDirectory() + "/credential.json");
                 if (f.exists()) {
                     Log.i(TAG, "Found custom credential file in sdcard - using it for testing");
                     try {
@@ -50,7 +55,7 @@ public class ConfigLoader {
                 } else {
                     Log.i(TAG, "Loading credentials from resource file");
                     credentialText = FileUtil.readFile(resources.openRawResource(R.raw.credential));
-                }
+                }*/
                 break;
         }
 

--- a/app/src/main/java/com/elavon/converge/config/ConfigLoader.java
+++ b/app/src/main/java/com/elavon/converge/config/ConfigLoader.java
@@ -37,25 +37,6 @@ public class ConfigLoader {
             case TEST:
             default:
                 configResource = R.raw.config_test;
-                /*
-                * Commenting this default credentials read logic from json file
-                * for AX-1723 - Credentials not downloading very first time when Converge app is
-                * installed from Mission Control
-                */
-                /*File f = new File(Environment.getExternalStorageDirectory() + "/credential.json");
-                if (f.exists()) {
-                    Log.i(TAG, "Found custom credential file in sdcard - using it for testing");
-                    try {
-                        credentialText = FileUtil.readFile(new FileInputStream(f));
-                    } catch (FileNotFoundException e) {
-                        e.printStackTrace();
-                        Log.i(TAG, "Failed to load credentials from sdcard - falling back to resource file");
-                        credentialText = FileUtil.readFile(resources.openRawResource(R.raw.credential));
-                    }
-                } else {
-                    Log.i(TAG, "Loading credentials from resource file");
-                    credentialText = FileUtil.readFile(resources.openRawResource(R.raw.credential));
-                }*/
                 break;
         }
 

--- a/app/src/main/java/com/elavon/converge/config/LoadBusinessIntentService.java
+++ b/app/src/main/java/com/elavon/converge/config/LoadBusinessIntentService.java
@@ -55,6 +55,7 @@ public class LoadBusinessIntentService extends IntentService {
     @Override
     public void onCreate() {
         super.onCreate();
+        Log.d(TAG, "Creating Business Intent Service for downloading business and processor data.");
         bindService(Intents.getComponentIntent(Intents.COMPONENT_POYNT_BUSINESS_SERVICE), serviceConnection,
                 BIND_AUTO_CREATE);
     }
@@ -62,6 +63,7 @@ public class LoadBusinessIntentService extends IntentService {
     @Override
     protected void onHandleIntent(Intent intent) {
         if (mBusinessService != null){
+            Log.d(TAG, "onHandleIntent- Business Service connected and is ready to load business and processor data.");
             loadBusiness();
             loadProcessorDataForBusiness();
         } else{
@@ -86,21 +88,22 @@ public class LoadBusinessIntentService extends IntentService {
     }
 
     private void loadProcessorDataForBusiness() {
-        Log.d(TAG, "loading business data with processor from cloud");
+        Log.d(TAG, "downaloading processor data for business from cloud");
         try {
             mBusinessService.getBusinessProcessorData(new IPoyntBusinessProcessorDataListener.Stub() {
                 @Override
                 public void onResponse(Business business, PoyntError poyntError) throws RemoteException {
                     if (poyntError != null) {
-                        Log.d(TAG, "loading business data with processor from cloud failed");
+                        Log.d(TAG, "downaloading processor data with business from cloud failed");
                     } else {
-                        Log.d(TAG, "business data with processor from cloud succeded");
+                        Log.d(TAG, "downaloading processor data with business from cloud succeded");
                         ElavonConvergeProcessorApplication.getInstance().setProcessorDataForBusiness(business);
                     }
                 }
             });
         } catch (RemoteException e) {
             e.printStackTrace();
+            Log.d(TAG, "Exception while downloading Processor data with business.");
         }
     }
 

--- a/app/src/main/java/com/elavon/converge/config/LoadBusinessIntentService.java
+++ b/app/src/main/java/com/elavon/converge/config/LoadBusinessIntentService.java
@@ -64,7 +64,7 @@ public class LoadBusinessIntentService extends IntentService {
         if (mBusinessService != null){
             loadBusiness();
             loadProcessorDataForBusiness();
-        }else{
+        } else{
             bindService(Intents.getComponentIntent(Intents.COMPONENT_POYNT_BUSINESS_SERVICE), serviceConnection,
                     BIND_AUTO_CREATE);
         }

--- a/app/src/main/java/com/elavon/converge/inject/AppModule.java
+++ b/app/src/main/java/com/elavon/converge/inject/AppModule.java
@@ -47,7 +47,7 @@ public class AppModule {
 
     public AppModule(final Context context) {
         this.context = context;
-        this.config = new ConfigLoader(context.getResources(), Config.Environment.TEST).load();
+        this.config = new ConfigLoader(context.getResources(), Config.Environment.LIVE).load();
     }
 
     public AppModule(final Context context, final Config config) {

--- a/app/src/main/java/com/elavon/converge/inject/AppModule.java
+++ b/app/src/main/java/com/elavon/converge/inject/AppModule.java
@@ -47,7 +47,7 @@ public class AppModule {
 
     public AppModule(final Context context) {
         this.context = context;
-        this.config = new ConfigLoader(context.getResources(), Config.Environment.LIVE).load();
+        this.config = new ConfigLoader(context.getResources(), Config.Environment.TEST).load();
     }
 
     public AppModule(final Context context, final Config config) {

--- a/app/src/main/java/com/elavon/converge/model/mapper/ConvergeMapper.java
+++ b/app/src/main/java/com/elavon/converge/model/mapper/ConvergeMapper.java
@@ -574,7 +574,8 @@ public class ConvergeMapper {
         }
 
         // set  EMV response tags - if it's EMV transaction
-        if (transaction.getFundingSource().getEntryDetails().getEntryMode()
+        if (transaction.getFundingSource() != null
+                && transaction.getFundingSource().getEntryDetails().getEntryMode()
                 == INTEGRATED_CIRCUIT_CARD
                 || transaction.getFundingSource().getEntryDetails().getEntryMode()
                 == CONTACTLESS_INTEGRATED_CIRCUIT_CARD) {

--- a/app/src/main/java/com/elavon/converge/processor/ConvergeClient.java
+++ b/app/src/main/java/com/elavon/converge/processor/ConvergeClient.java
@@ -89,11 +89,7 @@ public class ConvergeClient {
                     callback.onFailure(e);
                 }
             };
-            if (request != null) {
-                client.newCall(request).enqueue(cb);
-            } else {
-                callback.onFailure(new ConvergeClientException("Insufficient authorization for transaction."));
-            }
+            client.newCall(request).enqueue(cb);
         } catch (Exception e) {
             Log.e(TAG, e.getMessage(), e);
             callback.onFailure(new ConvergeClientException("Failed request with exception." + e.getMessage()));
@@ -102,16 +98,15 @@ public class ConvergeClient {
 
     public <T extends ElavonResponse> T callSync(final ElavonRequest model, final Class<T> responseClass) {
 
-        final Request request = getRequest(model);
-
         try {
+            final Request request = getRequest(model);
             final Response response = client.newCall(request).execute();
             if (response.isSuccessful()) {
                 return getResponse(response.body().string(), responseClass);
             } else {
                 throw new ConvergeClientException("Call not successful. Message: " + response.message());
             }
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new ConvergeClientException("Call not successful", e);
         }
     }

--- a/app/src/main/java/com/elavon/converge/processor/ConvergeClient.java
+++ b/app/src/main/java/com/elavon/converge/processor/ConvergeClient.java
@@ -88,7 +88,9 @@ public class ConvergeClient {
                 callback.onFailure(e);
             }
         };
-        client.newCall(request).enqueue(cb);
+        if(request != null) {
+            client.newCall(request).enqueue(cb);
+        }
     }
 
     public <T extends ElavonResponse> T callSync(final ElavonRequest model, final Class<T> responseClass) {
@@ -122,7 +124,8 @@ public class ConvergeClient {
                         .post(RequestBody.create(FORM_URL_ENCODED_TYPE, "xmldata=" + URLEncoder.encode(xmlMapper.write(request), "UTF-8")))
                         .build();
             } else {
-                throw new ConvergeClientException("Credentials data not updated from cloud, can't transact.", null);
+                Log.e(TAG, "Credentials data not updated from cloud, can't transact.", null);
+                return null;
             }
         } catch (Exception e) {
             throw new ConvergeClientException("Invalid XML request", e);

--- a/app/src/main/java/com/elavon/converge/processor/ConvergeClient.java
+++ b/app/src/main/java/com/elavon/converge/processor/ConvergeClient.java
@@ -122,7 +122,7 @@ public class ConvergeClient {
                         .post(RequestBody.create(FORM_URL_ENCODED_TYPE, "xmldata=" + URLEncoder.encode(xmlMapper.write(request), "UTF-8")))
                         .build();
             } else {
-                throw new ConvergeClientException("Credentials data not updated", null);
+                throw new ConvergeClientException("Credentials data not updated from cloud, can't transact.", null);
             }
         } catch (Exception e) {
             throw new ConvergeClientException("Invalid XML request", e);


### PR DESCRIPTION
Issue / Jira :
AX-1723: Credentials not downloading very first time when Converge app is installed from Mission Control

Targeted Release :
October release

Root Cause :
Merchant credentials were not being downloaded and updated in Converge Client for transactions to happen correctly.

Solution :
Removed the default credentials value read logic from Config TEST mode, now Converge app will only be able to transact if and only if it has correct credentials downloaded.

Notes :
NA

Test Cases :
No UI involved so no CheckPoynt test cases required.