### PR TITLE
EUAT-1796: Converge - Assure correct permissions to merch creds for s…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ allprojects {
 }
 
 def computeVersionCode() {
-    return 7
+    return 8
 }
 
 def computeVersionName() {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="poynt.permission.SECURITY_SERVICE" />
     <uses-permission android:name="poynt.permission.BUSINESS_SERVICE" />
+    <uses-permission android:name="poynt.permission.DOWNLOAD_MERCHANT_CREDENTIALS" />
     <uses-permission android:name="poynt.permission.CONFIGURATION_SERVICE" />
     <uses-permission android:name="poynt.permission.TRANSACTION_SERVICE" />
     <uses-permission android:name="co.poynt.orders.ACCESS_ORDERS" />

--- a/app/src/main/java/com/elavon/converge/config/LoadBusinessIntentService.java
+++ b/app/src/main/java/com/elavon/converge/config/LoadBusinessIntentService.java
@@ -94,7 +94,8 @@ public class LoadBusinessIntentService extends IntentService {
                 @Override
                 public void onResponse(Business business, PoyntError poyntError) throws RemoteException {
                     if (poyntError != null) {
-                        Log.d(TAG, "downaloading processor data with business from cloud failed");
+                        Log.d(TAG, "downloading processor data with business from cloud failed"
+                                + poyntError.getReason() != null ? " with reason " + poyntError.getReason() : "");
                     } else {
                         Log.d(TAG, "downaloading processor data with business from cloud succeded");
                         ElavonConvergeProcessorApplication.getInstance().setProcessorDataForBusiness(business);

--- a/app/src/main/java/com/elavon/converge/model/mapper/ConvergeMapper.java
+++ b/app/src/main/java/com/elavon/converge/model/mapper/ConvergeMapper.java
@@ -576,10 +576,11 @@ public class ConvergeMapper {
         // set  EMV response tags - if it's EMV transaction
         if (transaction != null
                 && transaction.getFundingSource() != null
-                && transaction.getFundingSource().getEntryDetails().getEntryMode()
+                && transaction.getFundingSource().getEntryDetails() != null
+                && (transaction.getFundingSource().getEntryDetails().getEntryMode()
                 == INTEGRATED_CIRCUIT_CARD
                 || transaction.getFundingSource().getEntryDetails().getEntryMode()
-                == CONTACTLESS_INTEGRATED_CIRCUIT_CARD) {
+                == CONTACTLESS_INTEGRATED_CIRCUIT_CARD)) {
             Map<String, String> emvTags = new HashMap<>();
 
             // NOTE do not pass CSN, atc and other non relevant tags in response as Poynt

--- a/app/src/main/java/com/elavon/converge/model/mapper/ConvergeMapper.java
+++ b/app/src/main/java/com/elavon/converge/model/mapper/ConvergeMapper.java
@@ -574,7 +574,8 @@ public class ConvergeMapper {
         }
 
         // set  EMV response tags - if it's EMV transaction
-        if (transaction.getFundingSource() != null
+        if (transaction != null
+                && transaction.getFundingSource() != null
                 && transaction.getFundingSource().getEntryDetails().getEntryMode()
                 == INTEGRATED_CIRCUIT_CARD
                 || transaction.getFundingSource().getEntryDetails().getEntryMode()


### PR DESCRIPTION
issue / Jira :
EUAT-1796: Converge - Assure correct permissions to merch creds for sanctioned apps

Targeted Release :
October Release

Root Cause :
Download merchant credentials service must be protected with a specific new custom permission other than the BUSINESS_SERVICE permission.

Solution :
provided a new DOWNLOAD_MERCHANT_CREDENTIALS permission to Converge app for it to be able to download merchant credentials, as without this permission no third party app would be able to download this user data.

Notes :
NA

Test Cases :
Test cases not required.