### PR TITLE
EUAT-1837: Converge - wrong amount sent to Elavon in Cashback scenario

### DIFF
--- a/app/src/main/java/com/elavon/converge/model/mapper/KeyedEbtMapper.java
+++ b/app/src/main/java/com/elavon/converge/model/mapper/KeyedEbtMapper.java
@@ -75,9 +75,12 @@ public class KeyedEbtMapper extends InterfaceMapper {
             request.setExpDate(CardUtil.getCardExpiry(t.getFundingSource().getCard()));
         }
 
-        request.setAmount(CurrencyUtil.getAmount(t.getAmounts().getTransactionAmount(), t.getAmounts().getCurrency()));
         if (t.getAmounts().getCashbackAmount() != null) {
             request.setCashbackAmount(CurrencyUtil.getAmount(t.getAmounts().getCashbackAmount(), t.getAmounts().getCurrency()));
+            request.setAmount(CurrencyUtil.getAmount(t.getAmounts().getTransactionAmount(), t.getAmounts().getCurrency()).add(
+                    CurrencyUtil.getAmount(t.getAmounts().getCashbackAmount(), t.getAmounts().getCurrency())));
+        } else {
+            request.setAmount(CurrencyUtil.getAmount(t.getAmounts().getTransactionAmount(), t.getAmounts().getCurrency()));
         }
         if (ebtType == EBTType.FOOD_STAMP_ELECTRONIC_VOUCHER) {
             request.setApprovalCode(t.getFundingSource().getEbtDetails().getElectronicVoucherApprovalCode());

--- a/app/src/main/java/com/elavon/converge/model/mapper/MsrDebitMapper.java
+++ b/app/src/main/java/com/elavon/converge/model/mapper/MsrDebitMapper.java
@@ -46,12 +46,9 @@ public class MsrDebitMapper extends InterfaceMapper {
         request.setEncryptedTrackData(t.getFundingSource().getCard().getTrack2data());
         request.setKsn(t.getFundingSource().getCard().getKeySerialNumber());
         request.setPosMode(ElavonPosMode.ICC_DUAL);
+        request.setAmount(CurrencyUtil.getAmount(t.getAmounts().getOrderAmount(), t.getAmounts().getCurrency()));
         if (t.getAmounts().getCashbackAmount() != null) {
             request.setCashbackAmount(CurrencyUtil.getAmount(t.getAmounts().getCashbackAmount(), t.getAmounts().getCurrency()));
-            request.setAmount(CurrencyUtil.getAmount(t.getAmounts().getOrderAmount() , t.getAmounts().getCurrency()).
-                    add(CurrencyUtil.getAmount(t.getAmounts().getCashbackAmount(), t.getAmounts().getCurrency())));
-        } else {
-            request.setAmount(CurrencyUtil.getAmount(t.getAmounts().getOrderAmount(), t.getAmounts().getCurrency()));
         }
         if (t.getAmounts().getTipAmount() != null) {
             request.setTipAmount(CurrencyUtil.getAmount(t.getAmounts().getTipAmount(), t.getAmounts().getCurrency()));

--- a/app/src/main/java/com/elavon/converge/model/mapper/MsrDebitMapper.java
+++ b/app/src/main/java/com/elavon/converge/model/mapper/MsrDebitMapper.java
@@ -46,9 +46,12 @@ public class MsrDebitMapper extends InterfaceMapper {
         request.setEncryptedTrackData(t.getFundingSource().getCard().getTrack2data());
         request.setKsn(t.getFundingSource().getCard().getKeySerialNumber());
         request.setPosMode(ElavonPosMode.ICC_DUAL);
-        request.setAmount(CurrencyUtil.getAmount(t.getAmounts().getOrderAmount(), t.getAmounts().getCurrency()));
         if (t.getAmounts().getCashbackAmount() != null) {
             request.setCashbackAmount(CurrencyUtil.getAmount(t.getAmounts().getCashbackAmount(), t.getAmounts().getCurrency()));
+            request.setAmount(CurrencyUtil.getAmount(t.getAmounts().getOrderAmount() , t.getAmounts().getCurrency()).
+                    add(CurrencyUtil.getAmount(t.getAmounts().getCashbackAmount(), t.getAmounts().getCurrency())));
+        } else {
+            request.setAmount(CurrencyUtil.getAmount(t.getAmounts().getOrderAmount(), t.getAmounts().getCurrency()));
         }
         if (t.getAmounts().getTipAmount() != null) {
             request.setTipAmount(CurrencyUtil.getAmount(t.getAmounts().getTipAmount(), t.getAmounts().getCurrency()));

--- a/app/src/main/java/com/elavon/converge/model/mapper/MsrEbtMapper.java
+++ b/app/src/main/java/com/elavon/converge/model/mapper/MsrEbtMapper.java
@@ -80,6 +80,8 @@ public class MsrEbtMapper extends InterfaceMapper {
         if (t.getAmounts().getCashbackAmount() != null) {
             request.setCashbackAmount(CurrencyUtil.getAmount(t.getAmounts().getCashbackAmount(),
                     t.getAmounts().getCurrency()));
+            request.setAmount(request.getAmount().add(
+                    CurrencyUtil.getAmount(t.getAmounts().getCashbackAmount(), t.getAmounts().getCurrency())));
         }
 
         if (t.getFundingSource().getVerificationData() != null) {


### PR DESCRIPTION
issue / Jira :
EUAT-1837: Converge - wrong amount sent to Elavon in Cashback scenario

Targeted Release :
October Release

Root Cause :
Total amount being displayed on Converge portal does not contain cashback amount

Solution :
added cashback amount to the total amount being sent in the transaction request for the mappers which had cashback amount implementation done already.

Notes :
NA

Test Cases :
Test cases not required.