### PR TITLE
AX-1785: Converge - VOIDs showing when settled (or pending settled)

### DIFF
--- a/app/src/main/java/com/elavon/converge/core/TransactionManager.java
+++ b/app/src/main/java/com/elavon/converge/core/TransactionManager.java
@@ -560,6 +560,8 @@ public class TransactionManager {
                                         convergeMapper.mapTransactionResponse(elavonResponse, transaction);
                                         try {
                                             // update the transactionId w/ new void txn Id and set parent
+                                            transaction.setAction(TransactionAction.REFUND);
+                                            transaction.setActionVoid(true);
                                             transaction.setParentId(transaction.getId());
                                             transaction.setId(UUID.randomUUID());
                                             listener.onResponse(transaction, requestId, null);


### PR DESCRIPTION
Issue / Jira :
AX-1785: Converge - VOIDs showing when settled (or pending settled)

Targeted Release :
October release 2018

Root Cause :
action was not set for VOID transaction when Converge returns with SUCCESS

Solution :
added the REFUND action and dit setActionVoid to true.

Notes :
NA

Test Cases :
NA