### PR TITLE
Added ssl_tip_amount in ssl_amount in case of ccauthonly

### DIFF
--- a/app/src/main/java/com/elavon/converge/model/mapper/MsrMapper.java
+++ b/app/src/main/java/com/elavon/converge/model/mapper/MsrMapper.java
@@ -34,8 +34,10 @@ public class MsrMapper extends InterfaceMapper {
             request.setEntryMode(ElavonEntryMode.ICC_FALLBACK);
         } else {
             request.setTransactionType(ElavonTransactionType.AUTH_ONLY);
+            //Because there's no info on Converge's doc for ssl_tip_amount in ccauthonly. So add the tip amount to total amount.
             if(transaction.getAmounts().getTipAmount() != null) {
-                request.setAmount(CurrencyUtil.getAmount(transaction.getAmounts().getTipAmount() + transaction.getAmounts().getOrderAmount(), transaction.getAmounts().getCurrency()));
+                request.setAmount(CurrencyUtil.getAmount(transaction.getAmounts().getTipAmount()
+                        + transaction.getAmounts().getOrderAmount(), transaction.getAmounts().getCurrency()));
             }
         }
         return request;

--- a/app/src/main/java/com/elavon/converge/model/mapper/MsrMapper.java
+++ b/app/src/main/java/com/elavon/converge/model/mapper/MsrMapper.java
@@ -34,6 +34,9 @@ public class MsrMapper extends InterfaceMapper {
             request.setEntryMode(ElavonEntryMode.ICC_FALLBACK);
         } else {
             request.setTransactionType(ElavonTransactionType.AUTH_ONLY);
+            if(transaction.getAmounts().getTipAmount() != null) {
+                request.setAmount(CurrencyUtil.getAmount(transaction.getAmounts().getTipAmount() + transaction.getAmounts().getOrderAmount(), transaction.getAmounts().getCurrency()));
+            }
         }
         return request;
     }

--- a/app/src/main/java/com/elavon/converge/model/mapper/MsrMapper.java
+++ b/app/src/main/java/com/elavon/converge/model/mapper/MsrMapper.java
@@ -34,11 +34,10 @@ public class MsrMapper extends InterfaceMapper {
             request.setEntryMode(ElavonEntryMode.ICC_FALLBACK);
         } else {
             request.setTransactionType(ElavonTransactionType.AUTH_ONLY);
-            //Because there's no info on Converge's doc for ssl_tip_amount in ccauthonly. So add the tip amount to total amount.
-            if(transaction.getAmounts().getTipAmount() != null) {
-                request.setAmount(CurrencyUtil.getAmount(transaction.getAmounts().getTipAmount()
-                        + transaction.getAmounts().getOrderAmount(), transaction.getAmounts().getCurrency()));
-            }
+            //Because there's no info on Converge's doc for ssl_tip_amount in ccauthonly. 
+            //So updating request's total amount with the transaction amount.
+            request.setAmount(CurrencyUtil.getAmount(transaction.getAmounts().getTransactionAmount()
+                    , transaction.getAmounts().getCurrency()));
         }
         return request;
     }


### PR DESCRIPTION
Issue / Jira :
https://poyntc.atlassian.net/browse/AX-1846

Targeted Release :
October, 2018

Root Cause :
Transaction was failing to show in Transactions List in case of ccauthonly with added tip.

Solution :
Add the tip amount in amount in case of ccauthonly.

Notes :


Test Cases :
