### PR TITLE
Update build.gradle bumping up version to 12

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ allprojects {
 }
 
 def computeVersionCode() {
-    return 11
+    return 12
 }
 
 def computeVersionName() {


### PR DESCRIPTION
Update build.gradle bumping up version to 12

Issue / Jira : https://poyntc.atlassian.net/browse/AX-2049


Targeted Release : Not deploy to live merchants.  Only deploy to test merchants.


Root Cause : Converge app does not have parameters to be passed to change Elavon End Points from test to live.


Solution Currently, upload a debug and live version of converge apps with different version numbers

Notes :


Test Cases :
Test on device activated against test merchant vs device activated on live merchant in US production DC.