### PR TITLE
bug fix :: send right cash amount to converge and avoid overwriting o…

### DIFF
--- a/app/src/main/java/com/elavon/converge/model/mapper/CashMapper.java
+++ b/app/src/main/java/com/elavon/converge/model/mapper/CashMapper.java
@@ -142,7 +142,8 @@ public class CashMapper extends InterfaceMapper {
     private ElavonTransactionRequest createRequest(final Transaction t) {
         final ElavonTransactionRequest request = new ElavonTransactionRequest();
         request.setPoyntUserId(t.getContext().getEmployeeUserId().toString());
-        request.setAmount(CurrencyUtil.getAmount(t.getAmounts().getTransactionAmount(), t.getAmounts().getCurrency()));
+        // Don't use transaction amount as for poynt transactionAmount = cash amount tendered by user
+        request.setAmount(CurrencyUtil.getAmount(t.getAmounts().getOrderAmount(), t.getAmounts().getCurrency()));
         return request;
     }
 

--- a/app/src/main/java/com/elavon/converge/model/mapper/ConvergeMapper.java
+++ b/app/src/main/java/com/elavon/converge/model/mapper/ConvergeMapper.java
@@ -14,6 +14,7 @@ import com.elavon.converge.model.ElavonTransactionResponse;
 import com.elavon.converge.model.ElavonTransactionSearchRequest;
 import com.elavon.converge.model.type.AVSResponse;
 import com.elavon.converge.model.type.CVV2Response;
+import com.elavon.converge.model.type.CardType;
 import com.elavon.converge.model.type.ElavonTransactionType;
 import com.elavon.converge.model.type.ResponseCodes;
 import com.elavon.converge.model.type.SignatureImageType;
@@ -563,21 +564,24 @@ public class ConvergeMapper {
                 || etResponse.getResponseCode() == ResponseCodes.AP
                 || ElavonResponse.RESULT_MESSAGE.APPROVAL.equals(etResponse.getResultMessage())
                 || ElavonResponse.RESULT_MESSAGE.PARTIAL_APPROVAL.equals(etResponse.getResultMessage())) {
-            // update the transaction amount
-            TransactionAmounts amounts = transaction.getAmounts();
-            if (etResponse.getAmount() != null) {
-                amounts.setTransactionAmount(CurrencyUtil.getAmount(etResponse.getAmount(),
-                        transaction.getAmounts().getCurrency()));
-                if (etResponse.getCashbackAmount() != null) {
-                    amounts.setCashbackAmount(CurrencyUtil.getAmount(etResponse.getCashbackAmount(),
+            // don't set amounts for cash transaction types
+            if (etResponse.getCardType() != CardType.CASH) {
+                // update the transaction amount
+                TransactionAmounts amounts = transaction.getAmounts();
+                if (etResponse.getAmount() != null) {
+                    amounts.setTransactionAmount(CurrencyUtil.getAmount(etResponse.getAmount(),
                             transaction.getAmounts().getCurrency()));
-                }
-            } else if (etResponse.getBaseAmount() != null) {
-                amounts.setTransactionAmount(CurrencyUtil.getAmount(etResponse.getBaseAmount(),
-                        transaction.getAmounts().getCurrency()));
-                if (etResponse.getCashbackAmount() != null) {
-                    amounts.setCashbackAmount(CurrencyUtil.getAmount(etResponse.getCashbackAmount(),
+                    if (etResponse.getCashbackAmount() != null) {
+                        amounts.setCashbackAmount(CurrencyUtil.getAmount(etResponse.getCashbackAmount(),
+                                transaction.getAmounts().getCurrency()));
+                    }
+                } else if (etResponse.getBaseAmount() != null) {
+                    amounts.setTransactionAmount(CurrencyUtil.getAmount(etResponse.getBaseAmount(),
                             transaction.getAmounts().getCurrency()));
+                    if (etResponse.getCashbackAmount() != null) {
+                        amounts.setCashbackAmount(CurrencyUtil.getAmount(etResponse.getCashbackAmount(),
+                                transaction.getAmounts().getCurrency()));
+                    }
                 }
             }
         }


### PR DESCRIPTION
…f transaction amount from converge response for cash txn

Root Cause :
Poynt transactionAmount value for cash txn is the amount tendered by user. As such instead of passing the actual cash txn value we were passing amount tendered to Converge server 

Solution :
Replace transactionAmount with orderAmount in Converge request.
Also avoid overwriting transactionAmount value when mapping the Converge response for cash txns
